### PR TITLE
Fix navigation buttons

### DIFF
--- a/src/LeaptimeManager/appBackup.py
+++ b/src/LeaptimeManager/appBackup.py
@@ -59,22 +59,12 @@ COL_NAME, COL_FILENAME, COL_CREATED, COL_REPEAT, COL_LOCATION = range(5)
 
 class AppBackup():
 	
-	def __init__(self, builder, window, stack, button_back, button_forward, button_apply, app_backup=False) -> None:
+	def __init__(self, builder, window, stack) -> None:
 		module_logger.info("Initializing App backup module...")
 		self.builder = builder
 		self.window = window
 		self.stack = stack
 		self.db_manager = appbackup_db()
-		
-		# nav buttons
-		self.button_back = button_back
-		self.button_forward = button_forward
-		self.button_apply = button_apply
-		
-		if app_backup:
-			self.button_back.connect("clicked", self.back_callback)
-			self.button_forward.connect("clicked", self.forward_callback)
-			self.button_apply.connect("clicked", self.forward_callback)
 		
 		# Existing backup list treeview
 		self.allbackup_tree = self.builder.get_object("treeview_all_appbackup_list")
@@ -496,3 +486,15 @@ class AppBackup():
 		# On remove button press
 		module_logger.debug(_("Removing backup from database list."))
 		show_message(self.window, _("This feature has not been implented yet. Please wait for future releases."))
+	
+	def reload_nav_btns(self, button_back, button_forward, button_apply, app_backup=False):
+		
+		# nav buttons
+		self.button_back = button_back
+		self.button_forward = button_forward
+		self.button_apply = button_apply
+		
+		if app_backup:
+			self.button_back.connect("clicked", self.back_callback)
+			self.button_forward.connect("clicked", self.forward_callback)
+			self.button_apply.connect("clicked", self.forward_callback)

--- a/src/LeaptimeManager/dataBackup.py
+++ b/src/LeaptimeManager/dataBackup.py
@@ -63,7 +63,7 @@ class UserData():
 	GUI class for backing up and restoring user data
 	using rsync
 	"""
-	def __init__(self, builder, window, stack, button_back, button_forward, button_apply, user_data=False) -> None:
+	def __init__(self, builder, window, stack) -> None:
 		module_logger.info(_("Initializing user data backup class..."))
 		self.builder = builder
 		self.window = window
@@ -75,16 +75,6 @@ class UserData():
 		# backup default settings
 		self.tar_archive = None
 		self.follow_links = True
-		
-		# nav buttons
-		self.button_back = button_back
-		self.button_forward = button_forward
-		self.button_apply = button_apply
-		
-		if user_data:
-			self.button_back.connect("clicked", self.back_callback)
-			self.button_forward.connect("clicked", self.forward_callback)
-			self.button_apply.connect("clicked", self.forward_callback)
 		
 		# entries
 		self.backup_name_entry = self.builder.get_object("data_backup_name")
@@ -591,3 +581,15 @@ class UserData():
 		self.button_back.show()
 		self.button_forward.show()
 		show_message(self.window, _("This feature has not been implented yet. Please wait for future releases."))
+	
+	def reload_nav_btns(self, button_back, button_forward, button_apply, app_backup=False):
+		
+		# nav buttons
+		self.button_back = button_back
+		self.button_forward = button_forward
+		self.button_apply = button_apply
+		
+		if app_backup:
+			self.button_back.connect("clicked", self.back_callback)
+			self.button_forward.connect("clicked", self.forward_callback)
+			self.button_apply.connect("clicked", self.forward_callback)

--- a/src/LeaptimeManager/gui.py
+++ b/src/LeaptimeManager/gui.py
@@ -158,8 +158,9 @@ class LeaptimeManagerWindow():
 		# Show all drop-down menu options
 		menu.show_all()
 		
-		self.UserData = UserData(self.builder, self.window, self.userdata_stack,
-			    self.button_back, self.button_forward, self.button_apply, self.user_data)
+		self.AppBackup = AppBackup(self.builder, self.window, self.appbackup_stack)
+		
+		self.UserData = UserData(self.builder, self.window, self.userdata_stack)
 		self.show_UserData_stack(self.window)
 	
 	def open_about(self, signal, widget):
@@ -183,9 +184,8 @@ class LeaptimeManagerWindow():
 		self.appbackup_stack.set_visible(True)
 		self.appbackup_stack.set_sensitive(True)
 		self.app_backup = True
+		self.AppBackup.reload_nav_btns(self.button_back, self.button_forward, self.button_apply, self.app_backup)
 		
-		self.AppBackup = AppBackup(self.builder, self.window, self.appbackup_stack,
-			    self.button_back, self.button_forward, self.button_apply, self.app_backup)
 		self.AppBackup.load_mainpage()
 	
 	def show_UserData_stack(self, widget):
@@ -198,9 +198,8 @@ class LeaptimeManagerWindow():
 		self.userdata_stack.set_visible(True)
 		self.userdata_stack.set_sensitive(True)
 		self.user_data = True
+		self.UserData.reload_nav_btns(self.button_back, self.button_forward, self.button_apply, self.app_backup)
 		
-		self.UserData = UserData(self.builder, self.window, self.userdata_stack,
-			    self.button_back, self.button_forward, self.button_apply, self.user_data)
 		self.UserData.load_mainpage()
 	
 	def on_add_button(self, widget):


### PR DESCRIPTION
- We use same back-forward nav buttons for all the modules. This creates confusion when clicking navigation buttons and prevents loading correct pages from the active modules.
- Navigation buttons are reloaded every time user chooses different modules.