### PR TITLE
Override dh_python to include python depends

### DIFF
--- a/debian/requires.txt
+++ b/debian/requires.txt
@@ -1,0 +1,6 @@
+aptdaemon
+configobj
+PyGObject
+python-apt
+setproctitle
+tldextract

--- a/debian/rules
+++ b/debian/rules
@@ -26,3 +26,6 @@ override_dh_auto_build:
 
 override_dh_install:
 	dh_install -O--buildsystem=meson
+
+override_dh_python3:
+	dh_python3 -O--buildsystem=meson --requires debian/requires.txt


### PR DESCRIPTION
- Override dh_python3 to read python dependencies from file requires.txt